### PR TITLE
Handle missing CRS when converting raster polygons

### DIFF
--- a/R/cloneMap.R
+++ b/R/cloneMap.R
@@ -14,14 +14,22 @@ raster_to_sf_polygons <- function(raster_obj, predicate){
   raster_crs_text <- tryCatch({
     raster::crs(raster_obj, asText = TRUE)
   }, error = function(e) "")
-  crs <- if( is.null(raster_crs_text) || raster_crs_text == "" ){
-    sf::NA_crs_
+
+  crs <- if( is.null(raster_crs_text) || isTRUE(raster_crs_text == "") ){
+    NULL
   }else{
     sf::st_crs(raster_crs_text)
   }
 
+  assign_crs <- function(geometry){
+    if( !is.null(crs) ){
+      sf::st_crs(geometry) <- crs
+    }
+    geometry
+  }
+
   if( !any(selected) ){
-    empty_geom <- sf::st_sfc( sf::st_geometrycollection(), crs = crs )
+    empty_geom <- assign_crs( sf::st_sfc( sf::st_geometrycollection() ) )
 
     return( sf::st_sf( geometry = empty_geom ) )
   }
@@ -44,9 +52,7 @@ raster_to_sf_polygons <- function(raster_obj, predicate){
                      byrow = TRUE )
     sf::st_polygon( list( ring ) )
   })
-
-
-  geometry <- sf::st_sfc( polygons, crs = crs )
+  geometry <- assign_crs( sf::st_sfc( polygons ) )
 
   sf_obj <- sf::st_sf( value = values[cells], geometry = geometry )
   sf::st_agr( sf_obj ) <- "constant"


### PR DESCRIPTION
## Summary
- avoid passing invalid CRS values to `sf::st_sfc()` when raster data has no coordinate reference system
- apply the raster CRS to generated geometries only when one is available

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd3868ce68832fb5205517613a5f3a